### PR TITLE
fix runnable repository entrypoint

### DIFF
--- a/dataset/dataset_manager.py
+++ b/dataset/dataset_manager.py
@@ -5,7 +5,13 @@ from torchvision import transforms
 import numpy as np
 import pickle as pkl
 
-from .data_utils import load_amat_file, RotMNIST, split_train_val, get_bg_rot_data, EqDataset
+from .data_utils import (
+    load_amat_file,
+    RotMNIST,
+    split_train_val,
+    get_bg_rot_data,
+    EqDataset,
+)
 
 
 class DatasetManager:
@@ -18,6 +24,7 @@ class DatasetManager:
         bs (int): Batch size for data loading.
         num_workers (int): Number of workers for data loading.
     """
+
     def __init__(self, cfg, overfit=False):
         self.cfg = cfg
         self.overfit = overfit
@@ -30,7 +37,14 @@ class DatasetManager:
         else:
             self.bs = self.data.batch_size
             self.num_workers = self.data.num_workers
-    
+
+    def _split_dataset(self, dataset, val_fraction=0.2):
+        """Split a dataset into training and validation sets with a fixed seed."""
+        val_size = int(len(dataset) * val_fraction)
+        train_size = len(dataset) - val_size
+        generator = torch.Generator().manual_seed(42)
+        return random_split(dataset, [train_size, val_size], generator=generator)
+
     def get_dataloader(self):
         """
         Returns appropriate data loaders based on the specified dataset in the configuration.
@@ -38,26 +52,26 @@ class DatasetManager:
         Returns:
             tuple: Data loaders for training, validation, and testing.
         """
-        dataset = self.cfg.exp.model.dataset
-        if dataset == 'cifar10':
+        dataset = self.cfg.exp.model.dataset.lower()
+        if dataset == "cifar10":
             return self._load_cifar10()
-        elif dataset == 'mnist-noise':
+        elif dataset == "mnist-noise":
             return self._load_mnist_noise()
-        elif dataset == 'mnist-bg-rot':
+        elif dataset == "mnist-bg-rot":
             return self._load_mnist_bg_rot()
-        elif dataset == 'norb':
+        elif dataset == "norb":
             return self._load_norb()
-        elif dataset == 'smallnorb':
+        elif dataset == "smallnorb":
             return self._load_smallnorb()
-        elif dataset == 'rot-mnist':
+        elif dataset in ("rot-mnist", "rot"):
             return self._load_rot_mnist()
-        elif dataset == 'phiflow':
+        elif dataset == "phiflow":
             return self._load_phiflow()
-        elif dataset == 'rectangles':
+        elif dataset == "rectangles":
             pass
         else:
             raise ValueError(f"Unsupported dataset: {dataset}")
-        
+
     def _load_cifar10(self):
         """
         Loads the CIFAR-10 dataset with appropriate transformations.
@@ -65,12 +79,18 @@ class DatasetManager:
         Returns:
             tuple: Data loaders for CIFAR-10 training, validation, and test sets.
         """
-        transform = transforms.Compose([
-            transforms.ToTensor(),
-            transforms.Normalize((0.4914, 0.4822, 0.4465), (0.247, 0.243, 0.261))
-        ])
-        train_dataset = torchvision.datasets.CIFAR10(root=self.data.path, train=True, transform=transform, download=True)
-        test_dataset = torchvision.datasets.CIFAR10(root=self.data.path, train=False, transform=transform, download=True)
+        transform = transforms.Compose(
+            [
+                transforms.ToTensor(),
+                transforms.Normalize((0.4914, 0.4822, 0.4465), (0.247, 0.243, 0.261)),
+            ]
+        )
+        train_dataset = torchvision.datasets.CIFAR10(
+            root=self.data.path, train=True, transform=transform, download=True
+        )
+        test_dataset = torchvision.datasets.CIFAR10(
+            root=self.data.path, train=False, transform=transform, download=True
+        )
         train_dataset, valid_dataset = self._split_dataset(train_dataset)
         return self._create_dataloaders(train_dataset, valid_dataset, test_dataset)
 
@@ -97,7 +117,9 @@ class DatasetManager:
             tuple: Data loaders for MNIST BG-rot training, validation, and test sets.
         """
         train_X, train_Y, test_X, test_Y = get_bg_rot_data()
-        train_X, train_Y, val_X, val_Y = split_train_val(train_X, train_Y, val_fraction=0.2)
+        train_X, train_Y, val_X, val_Y = split_train_val(
+            train_X, train_Y, val_fraction=0.2
+        )
         train_dataset = TensorDataset(train_X, train_Y)
         valid_dataset = TensorDataset(val_X, val_Y)
         test_dataset = TensorDataset(test_X, test_Y)
@@ -110,11 +132,13 @@ class DatasetManager:
         Returns:
             tuple: Data loaders for NORB training, validation, and test sets.
         """
-        train_X = np.load(self.cfg.exp.data.path + '/train_X.npy', allow_pickle=True)
-        train_Y = np.load(self.cfg.exp.data.path + '/train_Y.npy', allow_pickle=True)
-        test_X = np.load(self.cfg.exp.data.path + '/test_X.npy', allow_pickle=True)
-        test_Y = np.load(self.cfg.exp.data.path + '/test_Y.npy', allow_pickle=True)
-        train_X, train_Y, val_X, val_Y = split_train_val(torch.FloatTensor(train_X), torch.FloatTensor(train_Y), val_fraction=0.2)
+        train_X = np.load(self.cfg.exp.data.path + "/train_X.npy", allow_pickle=True)
+        train_Y = np.load(self.cfg.exp.data.path + "/train_Y.npy", allow_pickle=True)
+        test_X = np.load(self.cfg.exp.data.path + "/test_X.npy", allow_pickle=True)
+        test_Y = np.load(self.cfg.exp.data.path + "/test_Y.npy", allow_pickle=True)
+        train_X, train_Y, val_X, val_Y = split_train_val(
+            torch.FloatTensor(train_X), torch.FloatTensor(train_Y), val_fraction=0.2
+        )
         train_dataset = TensorDataset(train_X, train_Y)
         valid_dataset = TensorDataset(val_X, val_Y)
         test_dataset = TensorDataset(test_X, test_Y)
@@ -127,11 +151,19 @@ class DatasetManager:
         Returns:
             tuple: Data loaders for SmallNORB training, validation, and test sets.
         """
-        with open(self.cfg.exp.data.path, 'rb') as f:
+        with open(self.cfg.exp.data.path, "rb") as f:
             data = pkl.load(f)
-        train_X, train_Y = torch.FloatTensor(data['train_X']), torch.FloatTensor(data['train_Y'])
-        test_X, test_Y = torch.FloatTensor(data['test_X']), torch.FloatTensor(data['test_Y'])
-        train_X, train_Y, val_X, val_Y = split_train_val(train_X, train_Y, val_fraction=0.2)
+        train_X, train_Y = (
+            torch.FloatTensor(data["train_X"]),
+            torch.FloatTensor(data["train_Y"]),
+        )
+        test_X, test_Y = (
+            torch.FloatTensor(data["test_X"]),
+            torch.FloatTensor(data["test_Y"]),
+        )
+        train_X, train_Y, val_X, val_Y = split_train_val(
+            train_X, train_Y, val_fraction=0.2
+        )
         train_dataset = TensorDataset(train_X, train_Y)
         valid_dataset = TensorDataset(val_X, val_Y)
         test_dataset = TensorDataset(test_X, test_Y)
@@ -144,8 +176,13 @@ class DatasetManager:
         Returns:
             tuple: Data loaders for rotated MNIST training, validation, and test sets.
         """
-        train_set, train_labels = load_amat_file(self.cfg.exp.data.path + '/mnist_all_rotation_normalized_float_train_valid.amat')
-        test_set, test_labels = load_amat_file(self.cfg.exp.data.path + '/mnist_all_rotation_normalized_float_test.amat')
+        train_set, train_labels = load_amat_file(
+            self.cfg.exp.data.path
+            + "/mnist_all_rotation_normalized_float_train_valid.amat"
+        )
+        test_set, test_labels = load_amat_file(
+            self.cfg.exp.data.path + "/mnist_all_rotation_normalized_float_test.amat"
+        )
         train_dataset = RotMNIST(train_set, train_labels)
         test_dataset = RotMNIST(test_set, test_labels)
         train_dataset, valid_dataset = self._split_dataset(train_dataset)
@@ -158,25 +195,44 @@ class DatasetManager:
         Returns:
             tuple: Data loaders for PhiFlow training, validation, future test, and domain test sets.
         """
+
         def create_eq_dataset(task_list, sample_list):
             return EqDataset(
-                input_length=self.cfg.data.input_length, 
-                mid=self.cfg.data.mid, 
+                input_length=self.cfg.data.input_length,
+                mid=self.cfg.data.mid,
                 output_length=self.cfg.data.output_length,
-                direc=self.cfg.data_direc, 
-                task_list=task_list, 
-                sample_list=sample_list, 
-                stack=self.cfg.data.stack
+                direc=self.cfg.data_direc,
+                task_list=task_list,
+                sample_list=sample_list,
+                stack=self.cfg.data.stack,
             )
 
-        train_set = create_eq_dataset(self.cfg.data.train_task, self.cfg.data.train_time)
-        valid_set = create_eq_dataset(self.cfg.data.valid_task, self.cfg.data.valid_time)
-        test_set_future = create_eq_dataset(self.cfg.data.test_future_task, self.cfg.data.test_future_time)
-        test_set_domain = create_eq_dataset(self.cfg.data.test_domain_task, self.cfg.data.test_domain_time)
+        train_set = create_eq_dataset(
+            self.cfg.data.train_task, self.cfg.data.train_time
+        )
+        valid_set = create_eq_dataset(
+            self.cfg.data.valid_task, self.cfg.data.valid_time
+        )
+        test_set_future = create_eq_dataset(
+            self.cfg.data.test_future_task, self.cfg.data.test_future_time
+        )
+        test_set_domain = create_eq_dataset(
+            self.cfg.data.test_domain_task, self.cfg.data.test_domain_time
+        )
 
-        return self._create_dataloaders(train_set, valid_set, test_set_future, test_set_domain, task='regression')
+        return self._create_dataloaders(
+            train_set, valid_set, test_set_future, test_set_domain, task="regression"
+        )
 
-    def _create_dataloaders(self, train_dataset, valid_dataset, test_dataset=None, test_set_future=None, test_set_domain=None, task='classification'):
+    def _create_dataloaders(
+        self,
+        train_dataset,
+        valid_dataset,
+        test_dataset=None,
+        test_set_future=None,
+        test_set_domain=None,
+        task="classification",
+    ):
         """
         Create data loaders for training, validation, and testing.
 
@@ -191,26 +247,67 @@ class DatasetManager:
         Returns:
         tuple: Data loaders for training, validation, and testing.
         """
-        if task == 'classification':
+        if task == "classification":
             if self.overfit:
                 indices = list(range(self.bs))
                 train_dataset = Subset(train_dataset, indices)
                 valid_dataset = train_dataset
-            
-            train_loader = DataLoader(dataset=train_dataset, batch_size=self.bs, shuffle=True, pin_memory=True, num_workers=self.num_workers)
-            valid_loader = DataLoader(dataset=valid_dataset, batch_size=self.bs, shuffle=False, pin_memory=True, num_workers=self.num_workers)
-            test_loader = DataLoader(dataset=test_dataset, batch_size=self.data.batch_size, shuffle=False, pin_memory=True, num_workers=self.data.num_workers)
+
+            train_loader = DataLoader(
+                dataset=train_dataset,
+                batch_size=self.bs,
+                shuffle=True,
+                pin_memory=True,
+                num_workers=self.num_workers,
+            )
+            valid_loader = DataLoader(
+                dataset=valid_dataset,
+                batch_size=self.bs,
+                shuffle=False,
+                pin_memory=True,
+                num_workers=self.num_workers,
+            )
+            test_loader = DataLoader(
+                dataset=test_dataset,
+                batch_size=self.data.batch_size,
+                shuffle=False,
+                pin_memory=True,
+                num_workers=self.data.num_workers,
+            )
             return train_loader, valid_loader, test_loader
 
-        elif task == 'regression':
-            train_loader = DataLoader(dataset=train_dataset, batch_size=self.bs, shuffle=True, pin_memory=True, num_workers=self.num_workers)
-            valid_loader = DataLoader(dataset=valid_dataset, batch_size=self.bs, shuffle=False, pin_memory=True, num_workers=self.num_workers)
-            test_loader_future = DataLoader(dataset=test_set_future, batch_size=self.data.batch_size, shuffle=False, pin_memory=True, num_workers=self.data.num_workers)
-            test_loader_domain = DataLoader(dataset=test_set_domain, batch_size=self.data.batch_size, shuffle=False, pin_memory=True, num_workers=self.data.num_workers)
+        elif task == "regression":
+            train_loader = DataLoader(
+                dataset=train_dataset,
+                batch_size=self.bs,
+                shuffle=True,
+                pin_memory=True,
+                num_workers=self.num_workers,
+            )
+            valid_loader = DataLoader(
+                dataset=valid_dataset,
+                batch_size=self.bs,
+                shuffle=False,
+                pin_memory=True,
+                num_workers=self.num_workers,
+            )
+            test_loader_future = DataLoader(
+                dataset=test_set_future,
+                batch_size=self.data.batch_size,
+                shuffle=False,
+                pin_memory=True,
+                num_workers=self.data.num_workers,
+            )
+            test_loader_domain = DataLoader(
+                dataset=test_set_domain,
+                batch_size=self.data.batch_size,
+                shuffle=False,
+                pin_memory=True,
+                num_workers=self.data.num_workers,
+            )
             return train_loader, valid_loader, test_loader_future, test_loader_domain
 
         else:
-            raise ValueError("Unsupported task type. Supported types: 'classification', 'regression'.")
-
-
-
+            raise ValueError(
+                "Unsupported task type. Supported types: 'classification', 'regression'."
+            )

--- a/gmcnn/gm_convolution/gmconv_classification.py
+++ b/gmcnn/gm_convolution/gmconv_classification.py
@@ -6,10 +6,12 @@ import math
 from .conv_utils import get_central_indices
 from .gmconv import GMConvBase
 
+
 class GMConvCls(GMConvBase):
     """
     Group Matrix Convolution (GMConv) layer for classification tasks.
     """
+
     def __init__(self, group, order, nbr_size, group_matrix, out_channels, error=False):
         """
         Initializes the GMConvClassification layer.
@@ -22,14 +24,20 @@ class GMConvCls(GMConvBase):
             out_channels (int): The number of output channels.
             error (bool): Flag to enable error correction.
         """
-        super().__init__(group, order, nbr_size, group_matrix, out_channels, error=error)
+        super().__init__(
+            group, order, nbr_size, group_matrix, out_channels, error=error
+        )
 
         # Conditional initialization of err_params and col_indices if error correction is enabled
         if self.error:
             central_indices = get_central_indices(order, out_channels)
-            self.col_indices = [np.where(group_matrix[0] == point)[0][0] for point in central_indices]
+            self.col_indices = [
+                np.where(group_matrix[0] == point)[0][0] for point in central_indices
+            ]
 
-            self.err_params = nn.Parameter(torch.empty(out_channels, 1, len(self.target_elements)))
+            self.err_params = nn.Parameter(
+                torch.empty(out_channels, 1, len(self.target_elements))
+            )
             nn.init.kaiming_uniform_(self.err_params, a=math.sqrt(5))
 
     def forward(self, x):
@@ -42,15 +50,15 @@ class GMConvCls(GMConvBase):
         Returns:
             torch.Tensor: The output tensor after applying the GMConv operation.
         """
-        x = super().forward(x)
-
         # Ensure the input tensor has the expected shape
         if x.dim() != 4 or x.size(2) != 1:
-            raise ValueError("Input tensor must have shape (batch_size, in_channels, 1, vec_size)")
+            raise ValueError(
+                "Input tensor must have shape (batch_size, in_channels, 1, vec_size)"
+            )
 
         # Adjust input tensor based on the index matrix
         adj_input_tensor = x[:, :, 0, self.index_matrix]
-        res = torch.einsum('ojk, bikl -> bojl', self.weight_coeff, adj_input_tensor)
+        res = torch.einsum("ojk, bikl -> bojl", self.weight_coeff, adj_input_tensor)
 
         # Apply error correction if enabled
         if self.error:
@@ -71,7 +79,7 @@ class GMConvCls(GMConvBase):
             torch.Tensor: The tensor after applying error correction.
         """
         ip_mod = adj_input_tensor[:, :, :, self.col_indices]
-        err_op = torch.einsum('otk, biko -> bto', self.err_params, ip_mod)
+        err_op = torch.einsum("otk, biko -> bto", self.err_params, ip_mod)
 
         for i, idx in enumerate(self.col_indices):
             res[:, i, :, idx] += err_op[:, :, i]

--- a/runner.py
+++ b/runner.py
@@ -3,8 +3,8 @@ import torch.nn as nn
 import torch.optim as optim
 
 from torch.cuda.amp import autocast, GradScaler
-torch.set_float32_matmul_precision('medium')
-import wandb
+
+torch.set_float32_matmul_precision("medium")
 
 import pytorch_lightning as pl
 from datetime import datetime
@@ -17,52 +17,56 @@ from dataset.dataset_manager import DatasetManager
 
 from torch.optim.lr_scheduler import ReduceLROnPlateau, CosineAnnealingLR
 import torch.nn.utils as nnutils
-#from lightning.pytorch.utilities import grad_norm
+# from lightning.pytorch.utilities import grad_norm
 
 
-def train_one_epoch(epoch_idx, model, train_loader, optimizer, loss_fn, device, scaler, overfit):
-    running_loss = 0.
-    last_loss = 0.
+def train_one_epoch(
+    epoch_idx, model, train_loader, optimizer, loss_fn, device, scaler, overfit
+):
+    running_loss = 0.0
+    last_loss = 0.0
 
     for i, data in enumerate(train_loader):
         inputs, labels = data[0].to(device), data[1].to(device)
 
-        optimizer.zero_grad(set_to_none=True) # memory use reduction
-        
+        optimizer.zero_grad(set_to_none=True)  # memory use reduction
+
         # AMP Torch
-        with torch.autocast(device_type='cuda', dtype=torch.float16):
+        with torch.autocast(device_type="cuda", dtype=torch.float16):
             outputs = model(inputs)
 
             # Compute the loss and its gradients
             loss = loss_fn(outputs, labels)
-        
+
         # loss.backward()
         scaler.scale(loss).backward()
 
         # Adjust learning weights
-        #optimizer.step()
+        # optimizer.step()
         scaler.step(optimizer)
 
         scaler.update()
 
         running_loss += loss.item()
-        
+
         # overfit case
         if overfit:
             last_loss = running_loss
-            print('loss: {}'.format(last_loss))
-            running_loss = 0.
+            print("loss: {}".format(last_loss))
+            running_loss = 0.0
         else:
             if i % 20 == 19:
-                last_loss = running_loss / 20 # loss per batch
-                print('  batch {} loss: {}'.format(i + 1, last_loss))
-                running_loss = 0.
+                last_loss = running_loss / 20  # loss per batch
+                print("  batch {} loss: {}".format(i + 1, last_loss))
+                running_loss = 0.0
 
     return last_loss
 
 
 import os
-os.environ['WANDB_MODE'] = 'dryrun'
+
+os.environ["WANDB_MODE"] = "dryrun"
+
 
 @hydra.main(config_path="configs", config_name="config")
 def main(cfg: DictConfig):
@@ -70,36 +74,41 @@ def main(cfg: DictConfig):
 
     print(cfg)
 
-    device = torch.device('cuda:0' if torch.cuda.is_available() else 'cpu')
+    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
 
     scaler = GradScaler()
 
     model = GMCNN(cfg).to(device)
 
-    print("number of parameters:", sum(p.numel() for p in model.parameters() if p.requires_grad))
+    print(
+        "number of parameters:",
+        sum(p.numel() for p in model.parameters() if p.requires_grad),
+    )
 
     # get the optim and loss function
     criterion = nn.CrossEntropyLoss()
     optimizer = optim.AdamW(model.parameters(), lr=0.004, weight_decay=0.0153)
 
-    scheduler = ReduceLROnPlateau(optimizer, mode='min', patience=5, factor=0.7)
+    scheduler = ReduceLROnPlateau(optimizer, mode="min", patience=5, factor=0.7)
 
     overfit = False
-    #overfit = True
+    # overfit = True
 
     dataset_manager = DatasetManager(cfg, overfit=overfit)
     train_loader, valid_loader, test_loader = dataset_manager.get_dataloader()
 
     epochs = cfg.exp.trainer.max_epochs
-    best_vloss = 1_000_000.
+    best_vloss = 1_000_000.0
 
-    timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
 
     for epoch in range(epochs):
-        print('EPOCH {}:'.format(epoch + 1))
-        
+        print("EPOCH {}:".format(epoch + 1))
+
         model.train()
-        avg_loss = train_one_epoch(epoch, model, train_loader, optimizer, criterion, device, scaler, overfit)
+        avg_loss = train_one_epoch(
+            epoch, model, train_loader, optimizer, criterion, device, scaler, overfit
+        )
 
         running_vloss = 0.0
 
@@ -113,13 +122,13 @@ def main(cfg: DictConfig):
                 running_vloss += vloss
 
         avg_vloss = running_vloss / (i + 1)
-        print('LOSS train {} valid {}'.format(avg_loss, avg_vloss))
+        print("LOSS train {} valid {}".format(avg_loss, avg_vloss))
 
         if avg_vloss < best_vloss:
             best_vloss = avg_vloss
-            model_path = 'model_{}_{}'.format(timestamp, epoch)
+            model_path = "model_{}_{}".format(timestamp, epoch)
             torch.save(model.state_dict(), model_path)
-    
+
         scheduler.step(avg_vloss)
 
     correct = 0
@@ -133,10 +142,8 @@ def main(cfg: DictConfig):
             total += labels.size(0)
             correct += (predicted == labels).sum().item()
 
-    print(f'Accuracy of the network on the test images: {100 * correct // total} %')
+    print(f"Accuracy of the network on the test images: {100 * correct // total} %")
 
 
 if __name__ == "__main__":
     main()
-
-

--- a/tests/test_runnable_entrypoint.py
+++ b/tests/test_runnable_entrypoint.py
@@ -1,0 +1,55 @@
+from pathlib import Path
+import sys
+import types
+
+import torch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from dataset.dataset_manager import DatasetManager
+from gmcnn_base import GMCNN
+
+
+def build_cfg(dataset: str):
+    model = types.SimpleNamespace(
+        dataset=dataset,
+        group="cyclic",
+        order=32,
+        nbr=3,
+        lr=0.003,
+        dropout=0.2,
+        num_classes=10,
+        blocks=[types.SimpleNamespace(num_layers=1, out_channels=[8])],
+    )
+    data = types.SimpleNamespace(path="/tmp", batch_size=2, num_workers=0)
+    overfit = types.SimpleNamespace(bs=1)
+    exp = types.SimpleNamespace(model=model, data=data, overfit=overfit)
+    return types.SimpleNamespace(exp=exp)
+
+
+def test_dataset_manager_supports_cifar_and_rot_names():
+    cifar_cfg = build_cfg("cifar10")
+    rot_cfg = build_cfg("rot")
+
+    cifar_manager = DatasetManager(cifar_cfg)
+    rot_manager = DatasetManager(rot_cfg)
+
+    assert hasattr(cifar_manager, "_split_dataset")
+    assert rot_manager.cfg.exp.model.dataset == "rot"
+
+
+def test_dataset_manager_routes_rot_alias(monkeypatch):
+    cfg = build_cfg("rot")
+    manager = DatasetManager(cfg)
+
+    monkeypatch.setattr(manager, "_load_rot_mnist", lambda: "rot-loader")
+
+    assert manager.get_dataloader() == "rot-loader"
+
+
+def test_gmcnn_cifar_forward_runs():
+    cfg = build_cfg("cifar10")
+
+    output = GMCNN(cfg)(torch.randn(2, 3, 32, 32))
+
+    assert output.shape == (2, 10)


### PR DESCRIPTION
## Summary
- fix the CIFAR/classification entrypoint by removing the broken `GMConvCls.forward()` base-call path
- restore dataset splitting and normalize dataset-name routing so documented configs like `exp=cifar10` and `rot` work from a fresh clone
- remove the unused `wandb` hard import from `runner.py` and add a small runnable-entrypoint smoke test

## Verification
- `pytest tests/test_runnable_entrypoint.py`
- direct CIFAR forward smoke test in the isolated clean-HEAD worktree returned `(2, 10)`